### PR TITLE
Use SLAA336 for DCO calibrartion

### DIFF
--- a/tos/chips/msp430-small/clock_bcs/Msp430CalibrateDco.nc
+++ b/tos/chips/msp430-small/clock_bcs/Msp430CalibrateDco.nc
@@ -1,6 +1,5 @@
-
-/* Copyright (c) 2000-2003 The Regents of the University of California.
- * All rights reserved.
+/*
+ * Copyright (c) 2018 Tadashi G. Takaoka
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -8,10 +7,12 @@
  *
  * - Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
+ *
  * - Redistributions in binary form must reproduce the above copyright
  *   notice, this list of conditions and the following disclaimer in the
  *   documentation and/or other materials provided with the
  *   distribution.
+ *
  * - Neither the name of the copyright holders nor the names of
  *   its contributors may be used to endorse or promote products derived
  *   from this software without specific prior written permission.
@@ -28,21 +29,10 @@
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Tadashi G. Takaoka <tadashi.g.takaoka@gmail.com>
  */
 
-/**
- * @author Cory Sharp <cssharp@eecs.berkeley.edu>
- * @author Vlado Handziski <handzisk@tkn.tu-berlin.de>
- */
-
-interface Msp430ClockInit
-{
-  event void initClocks();
-  event void initTimerMicro();
-  event void initTimerMilli();
-
-  command void defaultInitClocks();
-  command void defaultInitTimerMicro();
-  command void defaultInitTimerMilli();
+interface Msp430CalibrateDco {
+    event void busyWaitCalibrateDco();
 }
-

--- a/tos/chips/msp430-small/clock_bcs/Msp430CalibrateDcoC.nc
+++ b/tos/chips/msp430-small/clock_bcs/Msp430CalibrateDcoC.nc
@@ -1,6 +1,5 @@
-
-/* Copyright (c) 2000-2003 The Regents of the University of California.
- * All rights reserved.
+/*
+ * Copyright (c) 2018 Tadashi G. Takaoka
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -8,10 +7,12 @@
  *
  * - Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
+ *
  * - Redistributions in binary form must reproduce the above copyright
  *   notice, this list of conditions and the following disclaimer in the
  *   documentation and/or other materials provided with the
  *   distribution.
+ *
  * - Neither the name of the copyright holders nor the names of
  *   its contributors may be used to endorse or promote products derived
  *   from this software without specific prior written permission.
@@ -28,21 +29,30 @@
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Tadashi G. Takaoka <tadashi.g.takaoka@gmail.com>
  */
 
-/**
- * @author Cory Sharp <cssharp@eecs.berkeley.edu>
- * @author Vlado Handziski <handzisk@tkn.tu-berlin.de>
- */
-
-interface Msp430ClockInit
-{
-  event void initClocks();
-  event void initTimerMicro();
-  event void initTimerMilli();
-
-  command void defaultInitClocks();
-  command void defaultInitTimerMicro();
-  command void defaultInitTimerMilli();
+configuration Msp430CalibrateDcoC {
+    uses interface Msp430CalibrateDco as CalibrateDco;
 }
+implementation {
+    components Msp430CalibrateDcoP, Msp430TimerC;
 
+    CalibrateDco = Msp430CalibrateDcoP;
+
+    Msp430CalibrateDcoP.Timer -> Msp430TimerC.TimerA;
+#if defined(__MSP430_HAS_TA2__)
+    Msp430CalibrateDcoP.Control -> Msp430TimerC.ControlA0;
+    Msp430CalibrateDcoP.Capture -> Msp430TimerC.CaptureA0;
+#elif defined(__MSP430_HAS_TA3__)
+#if defined(__MSP430G2402) || defined(__MSP430G2452) || defined(__MSP430G2553)
+    /* Some MSP430G2xx have TA3 but ACLK is connected to CCR0.CCIB */
+    Msp430CalibrateDcoP.Control -> Msp430TimerC.ControlA0;
+    Msp430CalibrateDcoP.Capture -> Msp430TimerC.CaptureA0;
+#else
+    Msp430CalibrateDcoP.Control -> Msp430TimerC.ControlA2;
+    Msp430CalibrateDcoP.Capture -> Msp430TimerC.CaptureA2;
+#endif
+#endif
+}

--- a/tos/chips/msp430-small/clock_bcs/Msp430CalibrateDcoP.nc
+++ b/tos/chips/msp430-small/clock_bcs/Msp430CalibrateDcoP.nc
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2018 Tadashi G. Takaoka
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * - Neither the name of the copyright holders nor the names of
+ *   its contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @author Tadashi G. Takaoka <tadashi.g.takaoka@gmail.com>
+ */
+
+module Msp430CalibrateDcoP {
+    uses {
+        interface Msp430CalibrateDco as CalibrateDco;
+        interface Msp430Timer as Timer;
+        interface Msp430TimerControl as Control;
+        interface Msp430Capture as Capture;
+    }
+}
+implementation {
+    enum {
+/*
+ * Basic Clock and BC2 differ in the size of the Range Select (RSEL)
+ * field.   x1xxx (BASIC_CLOCK) has 3 bits, x2xxx (BC2) has 4 bits.
+ * RSEL_MAX denotes where to start for calibration, RSEL_MASK is used
+ * to mask the entire RSEL field.
+ */
+#if defined(__MSP430_HAS_BASIC_CLOCK__)
+        RSEL_MASK = (RSEL2 | RSEL1 | RSEL0),
+        RSEL_MAX = RSEL2,
+#elif defined(__MSP430_HAS_BC2__)
+        RSEL_MASK = (RSEL3 | RSEL2 | RSEL1 | RSEL0),
+        RSEL_MAX = RSEL3,
+#else
+#error "Unknown clock system"
+#endif
+        DELTA = (uint16_t)(TARGET_DCO_HZ / (ACLK_HZ / 8)),
+        MAX_LOOP = 10000,
+        BCSCTL1_BITS = XT2OFF | DIVA_3, // ACLK = LFXT1 / 8.
+    };
+
+    event void CalibrateDco.busyWaitCalibrateDco() {
+        const uint16_t saved_bcsctl1 = BCSCTL1 & ~RSEL_MASK;
+        uint16_t previous;
+        int16_t loop;
+
+        BCSCTL1 = BCSCTL1_BITS | RSEL_MAX;
+        call Control.disableEvents();
+        call Control.setControlAsCapture(MSP430TIMER_CM_RISING, MSP430TIMER_CCI_B);
+        call Timer.setControl(MSP430TIMER_CONTINUOUS_MODE,
+                              MSP430TIMER_SMCLK,
+                              MSP430TIMER_CLOCKDIV_1);
+        while (!call Control.isInterruptPending())
+            ;
+        call Control.clearPendingInterrupt();
+        previous = call Capture.getEvent();
+        for (loop = 0; loop < MAX_LOOP; loop++) {
+            int16_t value;
+            while (!call Control.isInterruptPending())
+                ;
+            call Control.clearPendingInterrupt();
+            value = call Capture.getEvent() - previous;
+            previous = call Capture.getEvent();
+            value -= DELTA;
+            if (value == 0 || value == -1)
+                break; // calibrated.
+            if (value < 0) {
+                if (++DCOCTL == 0) {
+                    if (BCSCTL1 == (BCSCTL1_BITS | RSEL_MASK)) {
+                        DCOCTL = 0xff; // set fastest DCO.
+                        break;
+                    }
+                    BCSCTL1++;
+                }
+#if defined(__MSP430_HAS_BC2__) && defined(CALDCO_16MH_)
+                if (DCOCTL == CALDCO_16MHZ
+                    && BCSCTL1 == (BCSCTL1_BITS | CALBC1_16MHZ)) {
+                    break; // fastest DCO.
+                }
+#endif
+            } else {
+                if (--DCOCTL == 0) {
+                    if ((BCSCTL1 & RSEL_MASK) == 0) {
+                        DCOCTL = 0; // set slowest DCO.
+                        break;
+                    }
+                    BCSCTL1--;
+                }
+            }
+        }
+        BCSCTL1 = (BCSCTL1 & RSEL_MASK) | saved_bcsctl1;
+    }
+
+    async event void Timer.overflow() {}
+    async event void Capture.captured(uint16_t time) {}
+}

--- a/tos/chips/msp430-small/clock_bcs/Msp430ClockC.nc
+++ b/tos/chips/msp430-small/clock_bcs/Msp430ClockC.nc
@@ -32,17 +32,20 @@
 
 /**
  * @author Cory Sharp <cssharp@eecs.berkeley.edu>
- * @author Vlado Handziski <handzisk@tkn.tu-berlin.de>
  */
 
-interface Msp430ClockInit
+configuration Msp430ClockC
 {
-  event void initClocks();
-  event void initTimerMicro();
-  event void initTimerMilli();
-
-  command void defaultInitClocks();
-  command void defaultInitTimerMicro();
-  command void defaultInitTimerMilli();
+  provides interface Init;
+  provides interface Msp430ClockInit;
 }
+implementation
+{
+  components Msp430ClockP, McuSleepC;
+  components Msp430CalibrateDcoC;
 
+  Init = Msp430ClockP;
+  Msp430ClockInit = Msp430ClockP;
+  Msp430CalibrateDcoC.CalibrateDco -> Msp430ClockP;
+  McuSleepC.McuPowerOverride -> Msp430ClockP;
+}

--- a/tos/chips/msp430-small/timer/Msp430Timer.nc
+++ b/tos/chips/msp430-small/timer/Msp430Timer.nc
@@ -32,17 +32,29 @@
 
 /**
  * @author Cory Sharp <cssharp@eecs.berkeley.edu>
- * @author Vlado Handziski <handzisk@tkn.tu-berlin.de>
+ * @author Jan Hauer <hauer@tkn.tu-berlin.de>
  */
 
-interface Msp430ClockInit
-{
-  event void initClocks();
-  event void initTimerMicro();
-  event void initTimerMilli();
+//@author Cory Sharp <cssharp@eecs.berkeley.edu>
+//@author Jan Hauer <hauer@tkn.tu-berlin.de>
 
-  command void defaultInitClocks();
-  command void defaultInitTimerMicro();
-  command void defaultInitTimerMilli();
+#include "Msp430Timer.h"
+
+interface Msp430Timer
+{
+  async command uint16_t get();
+  async command bool isOverflowPending();
+  async command void clearOverflow();
+  async event void overflow();
+
+  async command void setMode( int mode );
+  async command int getMode();
+  async command void clear();
+  async command void enableEvents();
+  async command void disableEvents();
+  async command void setClockSource( uint16_t clockSource );
+  async command void setInputDivider( uint16_t inputDivider );
+  async command void setControl(int mode, int clockSource, int inputDivider);
+  // partial timer management, add more commands here as appropriate
 }
 

--- a/tos/chips/msp430-small/timer/Msp430TimerP.nc
+++ b/tos/chips/msp430-small/timer/Msp430TimerP.nc
@@ -123,6 +123,14 @@ implementation
     TxCTL = (TxCTL & ~(ID0|ID1)) | ((inputDivider << 6) & (ID0|ID1));
   }
 
+  async command void Timer.setControl(int mode, int clockSource, int inputDivider)
+  {
+    TxCTL = (TxCTL & ~(MC1|MC0|TxSSEL1|TxSSEL0|ID1|ID0))
+        | ((mode << 4) & (MC1|MC0))
+        | ((clockSource << 8) & (TxSSEL1|TxSSEL0))
+        | ((inputDivider << 6) & (ID1|ID0));
+  }
+
   async event void VectorTimerX0.fired()
   {
     signal Event.fired[0]();


### PR DESCRIPTION
- Introduces new Msp430CalibrateDco interface, configuration, and module
  based on TI's application note SLAA336A.

- For optimization, add new command Msp430Timer.setControl(mode,src,div).

- Thus modified Msp430ClockInit interface, Msp430ClockC and Msp430ClockP
  from upstream.